### PR TITLE
Update branding, metadata and README

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "orml"]
 	path = orml
-	url = https://github.com/Slixon-Technologies/open-runtime-module-library.git
+	url = https://github.com/balqaasem/open-runtime-module-library.git

--- a/.maintain/module-weight-template.hbs
+++ b/.maintain/module-weight-template.hbs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/.maintain/runtime-weight-template.hbs
+++ b/.maintain/runtime-weight-template.hbs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,10 +56,10 @@ codegen-units = 1
 [workspace.package]
 version = "0.9.81+dev"
 license = "GPL-3.0-or-later"
-authors = [ "Open Web3 Foundation", "Setheum Labs", "Slixon Technologies"]
+authors = [ "Afsall Labs", "Setheum Developers", "Setheum Foundation" ]
 edition = "2021"
-homepage = "https://setheum.xyz"
-repository = "https://github.com/Setheum-Labs/Setheum"
+homepage = "https://setheum.com"
+repository = "https://github.com/setheum/setheum"
 
 # The list of dependencies below (which can be both direct and indirect dependencies) are crates
 # that are suspected to be CPU-intensive, and that are unlikely to require debugging (as some of

--- a/HEADER-GPL3
+++ b/HEADER-GPL3
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This project contains some configuration files to help get started :hammer_and_w
 Clone this repository:
 
 ```bash
-git clone --recursive https://github.com/setheum/Setheum
+git clone --recursive https://github.com/setheum/setheum
 ```
 
 Install Rust:

--- a/README.md
+++ b/README.md
@@ -18,31 +18,30 @@ Setheum's Blockchain Network node Implementation in Rust, ready for hacking :roc
 
 <div align="center">
 
-[![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/Setheum-Labs/Setheum?color=yellow)](https://github.com/Setheum-Labs/Setheum/tags)
-[![License](https://img.shields.io/github/license/Setheum-Labs/Setheum?color=blue)](https://github.com/Setheum-Labs/Setheum/blob/master/LICENSE.md)
+[![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/setheum/setheum?color=yellow)](https://github.com/setheum/setheum/tags)
+[![License](https://img.shields.io/github/license/setheum/setheum?color=blue)](https://github.com/setheum/setheum/blob/master/LICENSE.md)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](docs/contributor/CONTRIBUTING.md)
 
 <br />
 
-[![Build](https://github.com/Setheum-Labs/Setheum/actions/workflows/rust.yml/badge.svg)](https://github.com/Setheum-Labs/Setheum/actions/workflows/rust.yml)
-[![CodeQL](https://github.com/Setheum-Labs/Setheum/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/Setheum-Labs/Setheum/actions/workflows/github-code-scanning/codeql)
+[![Build](https://github.com/setheum/setheum/actions/workflows/rust.yml/badge.svg)](https://github.com/setheum/setheum/actions/workflows/rust.yml)
+[![CodeQL](https://github.com/setheum/setheum/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/setheum/setheum/actions/workflows/github-code-scanning/codeql)
 
 <br />
 
-[![Website](https://img.shields.io/badge/Website-gray?logo=web)](https://setheum.xyz)
+[![Website](https://img.shields.io/badge/Website-gray?logo=web)](https://setheum.com)
 [![Twitter URL](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Ftwitter.com%2FSetheum)](https://twitter.com/Setheum)
 [![Telegram](https://img.shields.io/badge/Telegram-gray?logo=telegram)](https://t.me/SetheumNetwork)
-[![Medium](https://img.shields.io/badge/Medium-gray?logo=medium)](https://medium.com/setheum-labs)
-[![Lines of Code](https://img.shields.io/badge/LinesOfCode-gray?logo=LinesOfCode)](https://cloc.info/github.com/Setheum-Labs/Setheum)
+[![Lines of Code](https://img.shields.io/badge/LinesOfCode-gray?logo=LinesOfCode)](https://cloc.info/github.com/setheum/setheum)
 </div>
 
-> NOTE: SETHEUM means `Salam Eth`, `Super Eth`, `The house of gifts` and `gifted`. Originally from the name `Seth/Sheeth` mixed with `Ethereum`, it also stands for `Secure, Evergreen, Truthful, Heterogeneous, Economically Unbiased Market`.
+> NOTE: SETHEUM means `The house of Sheyth(also known as Seth the son of Adam)`. Originating from the name `Seth/Sheyth` with the `-eum` suffix whith means `House of`. Thus, The House of `Sheyth` - Our Smart Contract Framework is also called `Sheyth` and its VM is called `SetVM`.
 
 <!-- TOC -->
 - [Setheum - Powering The New Internet](#setheum---powering-the-new-internet)
   - [1.0. Introduction](#10-introduction)
     - [1.1. Setheum Chain](#11-setheum-chain)
-    - [1.2. Ethical DeFi](#12-ethical-defi)
+    - [1.2. DeFi](#12-ethical-defi)
       - [1.2.1. Ethical DeFi Projects](#121-ethical-defi-projects)
   - [2.0. Getting Started](#20-getting-started)
     - [2.1. Build](#21-build)
@@ -72,22 +71,19 @@ Setheum's Blockchain Network node Implementation in Rust, ready for hacking :roc
 
 ### 1.1. Setheum Chain
 
-Founded November 2019,Setheum achieves a high level of equilibrium in the trilemma by leveraging a Directed Acyclic Graph(DAG) to build the blockchain consensus - making it a Blockchain via DAG, achieve instant finality, high throughput and very fast blocktime while preserving network security and having a fairly decentralised network,
+Founded November 2019,Setheum is a light-speed decentralised blockchain network with WASM smart contracts, built from a mixture of what we have seen and considered to be some of the best solutions in the industry, improving on scalability, security, user experience, ethics,decentralisation and democratisation. Setheum intends to be the most complete blockchain network in the world. The AlephBFT Consensus Engine powers the Setheum Chain to have near instant finality, high throughput and high scalability and high security.
 
-Setheum is a light-speed decentralised blockchain network with EVM and WASM smart contracts, built from a mixture of what we have seen and considered to be some of the best solutions in the industry, improving on scalability, security, user experience, ethics,decentralisation and democratisation. Setheum intends to be the most complete blockchain network in the world. The AlephBFT Consensus Engine powers the Setheum Chain to have near instant finality, high throughput and high scalability and high security.
+### 1.2. DeFi
 
-### 1.2. Ethical DeFi
-
-Ethical DeFi Suite is the DeFi powerhouse of the Setheum Network, providing all kinds of top notch DeFi protocols including an AMM DEX (inspired by Uniswap v3), Ethical Zero-interest Halal Stablecoins that gives us the properties of both Fiat and Crypto with SlickUSD (USSD) and the Setter (SETR) using an Ethical Collateralized Debt Position (ECDP) mechanism that is over-Collateralized and multi-Collateralised and stable without compromising decentralisation or economic stability, offering stable cryptocurrencies that have scalable value and reliability, setheum provides just that, backed by crypto assets on an efficient zero-interest debt-based system.
+Setheum has a DeFi powerhouse, which is SEUSD (Setheum USD), Setheum USD is a stablecoin backed by Compute. It supports a DEX, a Liquid Staking Protocol, a launchpad etc. 
 
 #### 1.2.1. Ethical DeFi Projects:
 
-- `Edfis`: Ethical DeFi Suite
-  - `Edfis Swap Exchange`: AMM (Automated Market Maker) DEX Protocol inspired by Uniswap v3 design
-  - `Edfis Launchpad`: Launchpad Crowdsales protocol for bootstrapping pools on Edfis Exchange
-  - `Edfis Launchpool`: Launchpool protocol for bootstrapping pools on Edfis Exchange
-- `Setter`: Unpegged ECDP Stablecoin
-- `SlickUSD`: USD Pegged ECDP Stablecoin
+- The Setheum DeFi Suite
+- `Setheum USD (SEUSD)`: Compute-backed Stablecoin
+- `Staked SEUSD (SSEUSD)`: Liquid Staked SEUSD Stablecoin
+- `Setheum Swap`: AMM (Automated Market Maker) DEX Protocol inspired by Uniswap v3 design
+- `Setheum Launchpad`: Launchpad Crowdsales protocol for bootstrapping pools on Setheum Swap.
 
 ## 2.0. Getting Started
 
@@ -98,7 +94,7 @@ This project contains some configuration files to help get started :hammer_and_w
 Clone this repository:
 
 ```bash
-git clone --recursive https://github.com/Setheum-Labs/Setheum
+git clone --recursive https://github.com/setheum/Setheum
 ```
 
 Install Rust:

--- a/blockchain/aggregator/aggregator.rs
+++ b/blockchain/aggregator/aggregator.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/aggregator/src/aggregator.rs
+++ b/blockchain/aggregator/src/aggregator.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/aggregator/src/lib.rs
+++ b/blockchain/aggregator/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/clique/src/crypto.rs
+++ b/blockchain/clique/src/crypto.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/clique/src/incoming.rs
+++ b/blockchain/clique/src/incoming.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/clique/src/io.rs
+++ b/blockchain/clique/src/io.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/clique/src/lib.rs
+++ b/blockchain/clique/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/clique/src/manager/direction.rs
+++ b/blockchain/clique/src/manager/direction.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/clique/src/manager/mod.rs
+++ b/blockchain/clique/src/manager/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/clique/src/metrics.rs
+++ b/blockchain/clique/src/metrics.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/clique/src/mock.rs
+++ b/blockchain/clique/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/clique/src/outgoing.rs
+++ b/blockchain/clique/src/outgoing.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/clique/src/protocols/handshake.rs
+++ b/blockchain/clique/src/protocols/handshake.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/clique/src/protocols/mod.rs
+++ b/blockchain/clique/src/protocols/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/clique/src/protocols/negotiation.rs
+++ b/blockchain/clique/src/protocols/negotiation.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/clique/src/protocols/v1/mod.rs
+++ b/blockchain/clique/src/protocols/v1/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/clique/src/rate_limiting.rs
+++ b/blockchain/clique/src/rate_limiting.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/clique/src/service.rs
+++ b/blockchain/clique/src/service.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/clique/src/testing/clique_network.rs
+++ b/blockchain/clique/src/testing/clique_network.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/clique/src/testing/mod.rs
+++ b/blockchain/clique/src/testing/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/abft/common.rs
+++ b/blockchain/finality/src/abft/common.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/abft/crypto.rs
+++ b/blockchain/finality/src/abft/crypto.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/abft/current/mod.rs
+++ b/blockchain/finality/src/abft/current/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/abft/current/network.rs
+++ b/blockchain/finality/src/abft/current/network.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/abft/current/traits.rs
+++ b/blockchain/finality/src/abft/current/traits.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/abft/legacy/mod.rs
+++ b/blockchain/finality/src/abft/legacy/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/abft/legacy/network.rs
+++ b/blockchain/finality/src/abft/legacy/network.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/abft/legacy/traits.rs
+++ b/blockchain/finality/src/abft/legacy/traits.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/abft/mod.rs
+++ b/blockchain/finality/src/abft/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/abft/network.rs
+++ b/blockchain/finality/src/abft/network.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/abft/traits.rs
+++ b/blockchain/finality/src/abft/traits.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/abft/types.rs
+++ b/blockchain/finality/src/abft/types.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/aggregation/mod.rs
+++ b/blockchain/finality/src/aggregation/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/base_protocol/handler.rs
+++ b/blockchain/finality/src/base_protocol/handler.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/base_protocol/mod.rs
+++ b/blockchain/finality/src/base_protocol/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/base_protocol/service.rs
+++ b/blockchain/finality/src/base_protocol/service.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/block/mock/backend.rs
+++ b/blockchain/finality/src/block/mock/backend.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/block/mock/mod.rs
+++ b/blockchain/finality/src/block/mock/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/block/mock/status_notifier.rs
+++ b/blockchain/finality/src/block/mock/status_notifier.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/block/mod.rs
+++ b/blockchain/finality/src/block/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/block/substrate/chain_status.rs
+++ b/blockchain/finality/src/block/substrate/chain_status.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/block/substrate/finalizer.rs
+++ b/blockchain/finality/src/block/substrate/finalizer.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/block/substrate/justification.rs
+++ b/blockchain/finality/src/block/substrate/justification.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/block/substrate/mod.rs
+++ b/blockchain/finality/src/block/substrate/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/block/substrate/status_notifier.rs
+++ b/blockchain/finality/src/block/substrate/status_notifier.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/block/substrate/verification/cache.rs
+++ b/blockchain/finality/src/block/substrate/verification/cache.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/block/substrate/verification/mod.rs
+++ b/blockchain/finality/src/block/substrate/verification/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/block/substrate/verification/verifier.rs
+++ b/blockchain/finality/src/block/substrate/verification/verifier.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/compatibility.rs
+++ b/blockchain/finality/src/compatibility.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/crypto.rs
+++ b/blockchain/finality/src/crypto.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/data_io/chain_info.rs
+++ b/blockchain/finality/src/data_io/chain_info.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/data_io/data_interpreter.rs
+++ b/blockchain/finality/src/data_io/data_interpreter.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/data_io/data_provider.rs
+++ b/blockchain/finality/src/data_io/data_provider.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/data_io/data_store.rs
+++ b/blockchain/finality/src/data_io/data_store.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/data_io/legacy/data_interpreter.rs
+++ b/blockchain/finality/src/data_io/legacy/data_interpreter.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/data_io/legacy/data_provider.rs
+++ b/blockchain/finality/src/data_io/legacy/data_provider.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/data_io/legacy/data_store.rs
+++ b/blockchain/finality/src/data_io/legacy/data_store.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/data_io/legacy/mod.rs
+++ b/blockchain/finality/src/data_io/legacy/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/data_io/legacy/proposal.rs
+++ b/blockchain/finality/src/data_io/legacy/proposal.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/data_io/legacy/status_provider.rs
+++ b/blockchain/finality/src/data_io/legacy/status_provider.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/data_io/mod.rs
+++ b/blockchain/finality/src/data_io/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/data_io/proposal.rs
+++ b/blockchain/finality/src/data_io/proposal.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/data_io/status_provider.rs
+++ b/blockchain/finality/src/data_io/status_provider.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/finalization.rs
+++ b/blockchain/finality/src/finalization.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/idx_to_account.rs
+++ b/blockchain/finality/src/idx_to_account.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/import.rs
+++ b/blockchain/finality/src/import.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/justification/compatibility.rs
+++ b/blockchain/finality/src/justification/compatibility.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/justification/mod.rs
+++ b/blockchain/finality/src/justification/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/lib.rs
+++ b/blockchain/finality/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/metrics/all_block.rs
+++ b/blockchain/finality/src/metrics/all_block.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/metrics/chain_state.rs
+++ b/blockchain/finality/src/metrics/chain_state.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/metrics/finality_rate.rs
+++ b/blockchain/finality/src/metrics/finality_rate.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/metrics/mod.rs
+++ b/blockchain/finality/src/metrics/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/metrics/timing.rs
+++ b/blockchain/finality/src/metrics/timing.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/metrics/transaction_pool.rs
+++ b/blockchain/finality/src/metrics/transaction_pool.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/network/address_cache.rs
+++ b/blockchain/finality/src/network/address_cache.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/network/data/component.rs
+++ b/blockchain/finality/src/network/data/component.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/network/data/mod.rs
+++ b/blockchain/finality/src/network/data/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/network/data/split.rs
+++ b/blockchain/finality/src/network/data/split.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/network/gossip/metrics.rs
+++ b/blockchain/finality/src/network/gossip/metrics.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/network/gossip/mock.rs
+++ b/blockchain/finality/src/network/gossip/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/network/gossip/mod.rs
+++ b/blockchain/finality/src/network/gossip/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/network/gossip/service.rs
+++ b/blockchain/finality/src/network/gossip/service.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/network/mock.rs
+++ b/blockchain/finality/src/network/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/network/mod.rs
+++ b/blockchain/finality/src/network/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/network/session/compatibility.rs
+++ b/blockchain/finality/src/network/session/compatibility.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/network/session/connections.rs
+++ b/blockchain/finality/src/network/session/connections.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/network/session/data.rs
+++ b/blockchain/finality/src/network/session/data.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/network/session/discovery.rs
+++ b/blockchain/finality/src/network/session/discovery.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/network/session/handler.rs
+++ b/blockchain/finality/src/network/session/handler.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/network/session/manager.rs
+++ b/blockchain/finality/src/network/session/manager.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/network/session/mod.rs
+++ b/blockchain/finality/src/network/session/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/network/session/service.rs
+++ b/blockchain/finality/src/network/session/service.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/network/session/testing.rs
+++ b/blockchain/finality/src/network/session/testing.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/network/substrate.rs
+++ b/blockchain/finality/src/network/substrate.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/network/tcp.rs
+++ b/blockchain/finality/src/network/tcp.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/nodes.rs
+++ b/blockchain/finality/src/nodes.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/party/backup.rs
+++ b/blockchain/finality/src/party/backup.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/party/impls.rs
+++ b/blockchain/finality/src/party/impls.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/party/manager/aggregator.rs
+++ b/blockchain/finality/src/party/manager/aggregator.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/party/manager/authority.rs
+++ b/blockchain/finality/src/party/manager/authority.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/party/manager/mod.rs
+++ b/blockchain/finality/src/party/manager/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/party/manager/task.rs
+++ b/blockchain/finality/src/party/manager/task.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/party/mocks.rs
+++ b/blockchain/finality/src/party/mocks.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/party/mod.rs
+++ b/blockchain/finality/src/party/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/party/traits.rs
+++ b/blockchain/finality/src/party/traits.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/runtime_api.rs
+++ b/blockchain/finality/src/runtime_api.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/session.rs
+++ b/blockchain/finality/src/session.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/session_map.rs
+++ b/blockchain/finality/src/session_map.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/sync/data.rs
+++ b/blockchain/finality/src/sync/data.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/sync/forest/mod.rs
+++ b/blockchain/finality/src/sync/forest/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/sync/forest/vertex.rs
+++ b/blockchain/finality/src/sync/forest/vertex.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/sync/handler/mod.rs
+++ b/blockchain/finality/src/sync/handler/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/sync/handler/request_handler.rs
+++ b/blockchain/finality/src/sync/handler/request_handler.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/sync/message_limiter.rs
+++ b/blockchain/finality/src/sync/message_limiter.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/sync/metrics.rs
+++ b/blockchain/finality/src/sync/metrics.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/sync/mod.rs
+++ b/blockchain/finality/src/sync/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/sync/service.rs
+++ b/blockchain/finality/src/sync/service.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/sync/task_queue.rs
+++ b/blockchain/finality/src/sync/task_queue.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/sync/tasks.rs
+++ b/blockchain/finality/src/sync/tasks.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/sync/ticker.rs
+++ b/blockchain/finality/src/sync/ticker.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/sync_oracle.rs
+++ b/blockchain/finality/src/sync_oracle.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/testing/client_chain_builder.rs
+++ b/blockchain/finality/src/testing/client_chain_builder.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/testing/data_store.rs
+++ b/blockchain/finality/src/testing/data_store.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/testing/mocks/acceptance_policy.rs
+++ b/blockchain/finality/src/testing/mocks/acceptance_policy.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/testing/mocks/block_finalizer.rs
+++ b/blockchain/finality/src/testing/mocks/block_finalizer.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/testing/mocks/client.rs
+++ b/blockchain/finality/src/testing/mocks/client.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/testing/mocks/mod.rs
+++ b/blockchain/finality/src/testing/mocks/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/testing/mocks/proposal.rs
+++ b/blockchain/finality/src/testing/mocks/proposal.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/testing/mocks/single_action_mock.rs
+++ b/blockchain/finality/src/testing/mocks/single_action_mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/testing/mod.rs
+++ b/blockchain/finality/src/testing/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finality/src/testing/network.rs
+++ b/blockchain/finality/src/testing/network.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finalizer/src/commands.rs
+++ b/blockchain/finalizer/src/commands.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/finalizer/src/main.rs
+++ b/blockchain/finalizer/src/main.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/airdrop/src/lib.rs
+++ b/blockchain/modules/airdrop/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/airdrop/src/mock.rs
+++ b/blockchain/modules/airdrop/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/airdrop/src/tests.rs
+++ b/blockchain/modules/airdrop/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/aleph/src/impls.rs
+++ b/blockchain/modules/aleph/src/impls.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/aleph/src/lib.rs
+++ b/blockchain/modules/aleph/src/lib.rs
@@ -5,7 +5,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/aleph/src/mock.rs
+++ b/blockchain/modules/aleph/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/aleph/src/tests.rs
+++ b/blockchain/modules/aleph/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/aleph/src/traits.rs
+++ b/blockchain/modules/aleph/src/traits.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/asset-registry/src/lib.rs
+++ b/blockchain/modules/asset-registry/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/asset-registry/src/mock.rs
+++ b/blockchain/modules/asset-registry/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/asset-registry/src/tests.rs
+++ b/blockchain/modules/asset-registry/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/asset-registry/src/weights.rs
+++ b/blockchain/modules/asset-registry/src/weights.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/committee-management/src/impls.rs
+++ b/blockchain/modules/committee-management/src/impls.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/committee-management/src/lib.rs
+++ b/blockchain/modules/committee-management/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/committee-management/src/manager.rs
+++ b/blockchain/modules/committee-management/src/manager.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/committee-management/src/traits.rs
+++ b/blockchain/modules/committee-management/src/traits.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/currencies/runtime-api/src/lib.rs
+++ b/blockchain/modules/currencies/runtime-api/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/currencies/src/lib.rs
+++ b/blockchain/modules/currencies/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/currencies/src/mock.rs
+++ b/blockchain/modules/currencies/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/currencies/src/tests.rs
+++ b/blockchain/modules/currencies/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/currencies/src/weights.rs
+++ b/blockchain/modules/currencies/src/weights.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/ecdp-auctions/src/lib.rs
+++ b/blockchain/modules/ecdp-auctions/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/ecdp-auctions/src/mock.rs
+++ b/blockchain/modules/ecdp-auctions/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/ecdp-auctions/src/tests.rs
+++ b/blockchain/modules/ecdp-auctions/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/ecdp-auctions/src/weights.rs
+++ b/blockchain/modules/ecdp-auctions/src/weights.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/ecdp-loans/src/lib.rs
+++ b/blockchain/modules/ecdp-loans/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/ecdp-loans/src/mock.rs
+++ b/blockchain/modules/ecdp-loans/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/ecdp-loans/src/tests.rs
+++ b/blockchain/modules/ecdp-loans/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/ecdp-ussd-engine/src/lib.rs
+++ b/blockchain/modules/ecdp-ussd-engine/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/ecdp-ussd-engine/src/mock.rs
+++ b/blockchain/modules/ecdp-ussd-engine/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/ecdp-ussd-engine/src/tests.rs
+++ b/blockchain/modules/ecdp-ussd-engine/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/ecdp-ussd-engine/src/weights.rs
+++ b/blockchain/modules/ecdp-ussd-engine/src/weights.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/ecdp-ussd-treasury/src/lib.rs
+++ b/blockchain/modules/ecdp-ussd-treasury/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/ecdp-ussd-treasury/src/mock.rs
+++ b/blockchain/modules/ecdp-ussd-treasury/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/ecdp-ussd-treasury/src/tests.rs
+++ b/blockchain/modules/ecdp-ussd-treasury/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/ecdp-ussd-treasury/src/weights.rs
+++ b/blockchain/modules/ecdp-ussd-treasury/src/weights.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/ecdp/src/lib.rs
+++ b/blockchain/modules/ecdp/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/ecdp/src/mock.rs
+++ b/blockchain/modules/ecdp/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/ecdp/src/tests.rs
+++ b/blockchain/modules/ecdp/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/ecdp/src/weights.rs
+++ b/blockchain/modules/ecdp/src/weights.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/edfis-launchpad/src/lib.rs
+++ b/blockchain/modules/edfis-launchpad/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/edfis-launchpad/src/mock.rs
+++ b/blockchain/modules/edfis-launchpad/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/edfis-launchpad/src/tests.rs
+++ b/blockchain/modules/edfis-launchpad/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/edfis-launchpad/src/weights.rs
+++ b/blockchain/modules/edfis-launchpad/src/weights.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/edfis-oracle/src/lib.rs
+++ b/blockchain/modules/edfis-oracle/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/edfis-oracle/src/mock.rs
+++ b/blockchain/modules/edfis-oracle/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/edfis-oracle/src/tests.rs
+++ b/blockchain/modules/edfis-oracle/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/edfis-oracle/src/weights.rs
+++ b/blockchain/modules/edfis-oracle/src/weights.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/edfis-pay/src/lib.rs
+++ b/blockchain/modules/edfis-pay/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/edfis-pay/src/mock.rs
+++ b/blockchain/modules/edfis-pay/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/edfis-pay/src/tests.rs
+++ b/blockchain/modules/edfis-pay/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/edfis-pay/src/types.rs
+++ b/blockchain/modules/edfis-pay/src/types.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/edfis-pay/src/weights.rs
+++ b/blockchain/modules/edfis-pay/src/weights.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/edfis-swap-legacy/src/lib.rs
+++ b/blockchain/modules/edfis-swap-legacy/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/edfis-swap-legacy/src/mock.rs
+++ b/blockchain/modules/edfis-swap-legacy/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/edfis-swap-legacy/src/tests.rs
+++ b/blockchain/modules/edfis-swap-legacy/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/edfis-swap-legacy/src/weights.rs
+++ b/blockchain/modules/edfis-swap-legacy/src/weights.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/edfis-swap/src/lib.rs
+++ b/blockchain/modules/edfis-swap/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/edfis-swap/src/mock.rs
+++ b/blockchain/modules/edfis-swap/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/edfis-swap/src/tests.rs
+++ b/blockchain/modules/edfis-swap/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/edfis-swap/src/weights.rs
+++ b/blockchain/modules/edfis-swap/src/weights.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/elections/src/impls.rs
+++ b/blockchain/modules/elections/src/impls.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/elections/src/lib.rs
+++ b/blockchain/modules/elections/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/elections/src/mock.rs
+++ b/blockchain/modules/elections/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/elections/src/tests.rs
+++ b/blockchain/modules/elections/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/elections/src/traits.rs
+++ b/blockchain/modules/elections/src/traits.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm-bridge/src/lib.rs
+++ b/blockchain/modules/evm-bridge/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm-bridge/src/mock.rs
+++ b/blockchain/modules/evm-bridge/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm-bridge/src/tests.rs
+++ b/blockchain/modules/evm-bridge/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm-utility/macro/src/lib.rs
+++ b/blockchain/modules/evm-utility/macro/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm-utility/macro/tests/test.rs
+++ b/blockchain/modules/evm-utility/macro/tests/test.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm-utility/src/lib.rs
+++ b/blockchain/modules/evm-utility/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/benches/orml_benches.rs
+++ b/blockchain/modules/evm/benches/orml_benches.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/rpc/runtime_api/src/lib.rs
+++ b/blockchain/modules/evm/rpc/runtime_api/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/src/bench/mock.rs
+++ b/blockchain/modules/evm/src/bench/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/src/bench/mod.rs
+++ b/blockchain/modules/evm/src/bench/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/src/lib.rs
+++ b/blockchain/modules/evm/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/src/mock.rs
+++ b/blockchain/modules/evm/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/src/precompiles/blake2/eip_152.rs
+++ b/blockchain/modules/evm/src/precompiles/blake2/eip_152.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/src/precompiles/blake2/mod.rs
+++ b/blockchain/modules/evm/src/precompiles/blake2/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/src/precompiles/bn128.rs
+++ b/blockchain/modules/evm/src/precompiles/bn128.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/src/precompiles/ecrecover.rs
+++ b/blockchain/modules/evm/src/precompiles/ecrecover.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/src/precompiles/ecrecover_publickey.rs
+++ b/blockchain/modules/evm/src/precompiles/ecrecover_publickey.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/src/precompiles/identity.rs
+++ b/blockchain/modules/evm/src/precompiles/identity.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/src/precompiles/mod.rs
+++ b/blockchain/modules/evm/src/precompiles/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/src/precompiles/modexp.rs
+++ b/blockchain/modules/evm/src/precompiles/modexp.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/src/precompiles/ripemd.rs
+++ b/blockchain/modules/evm/src/precompiles/ripemd.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/src/precompiles/sha256.rs
+++ b/blockchain/modules/evm/src/precompiles/sha256.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/src/precompiles/sha3fips.rs
+++ b/blockchain/modules/evm/src/precompiles/sha3fips.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/src/runner/mod.rs
+++ b/blockchain/modules/evm/src/runner/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/src/runner/stack.rs
+++ b/blockchain/modules/evm/src/runner/stack.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/src/runner/state.rs
+++ b/blockchain/modules/evm/src/runner/state.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/src/runner/storage_meter.rs
+++ b/blockchain/modules/evm/src/runner/storage_meter.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/src/runner/tagged_runtime.rs
+++ b/blockchain/modules/evm/src/runner/tagged_runtime.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/src/tests.rs
+++ b/blockchain/modules/evm/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/evm/src/weights.rs
+++ b/blockchain/modules/evm/src/weights.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/idle-scheduler/Cargo.toml
+++ b/blockchain/modules/idle-scheduler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "idle-scheduler"
 version = "1.0.0"
-authors = ["Setheum Labs"]
+authors = [ "Afsall Labs", "Setheum Developers", "Setheum Foundation" ]
 edition = "2018"
 
 [dependencies]

--- a/blockchain/modules/idle-scheduler/src/lib.rs
+++ b/blockchain/modules/idle-scheduler/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/idle-scheduler/src/mock.rs
+++ b/blockchain/modules/idle-scheduler/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/idle-scheduler/src/tests.rs
+++ b/blockchain/modules/idle-scheduler/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/idle-scheduler/src/weights.rs
+++ b/blockchain/modules/idle-scheduler/src/weights.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/incentives/src/lib.rs
+++ b/blockchain/modules/incentives/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/incentives/src/mock.rs
+++ b/blockchain/modules/incentives/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/incentives/src/tests.rs
+++ b/blockchain/modules/incentives/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/incentives/src/weights.rs
+++ b/blockchain/modules/incentives/src/weights.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/nft/src/benchmarking.rs
+++ b/blockchain/modules/nft/src/benchmarking.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/nft/src/lib.rs
+++ b/blockchain/modules/nft/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/nft/src/mock.rs
+++ b/blockchain/modules/nft/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/nft/src/tests.rs
+++ b/blockchain/modules/nft/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/nft/src/weights.rs
+++ b/blockchain/modules/nft/src/weights.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/operations/src/impls.rs
+++ b/blockchain/modules/operations/src/impls.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/operations/src/lib.rs
+++ b/blockchain/modules/operations/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/operations/src/tests/mod.rs
+++ b/blockchain/modules/operations/src/tests/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/operations/src/tests/setup.rs
+++ b/blockchain/modules/operations/src/tests/setup.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/operations/src/tests/suite.rs
+++ b/blockchain/modules/operations/src/tests/suite.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/operations/src/traits.rs
+++ b/blockchain/modules/operations/src/traits.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/prices/src/lib.rs
+++ b/blockchain/modules/prices/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/prices/src/mock.rs
+++ b/blockchain/modules/prices/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/prices/src/tests.rs
+++ b/blockchain/modules/prices/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/prices/src/weights.rs
+++ b/blockchain/modules/prices/src/weights.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/support/src/bounded.rs
+++ b/blockchain/modules/support/src/bounded.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/support/src/ecdp.rs
+++ b/blockchain/modules/support/src/ecdp.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/support/src/edfis_launchpad.rs
+++ b/blockchain/modules/support/src/edfis_launchpad.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/support/src/edfis_swap.rs
+++ b/blockchain/modules/support/src/edfis_swap.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/support/src/edfis_swap_legacy.rs
+++ b/blockchain/modules/support/src/edfis_swap_legacy.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/support/src/evm.rs
+++ b/blockchain/modules/support/src/evm.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/support/src/incentives.rs
+++ b/blockchain/modules/support/src/incentives.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/support/src/lib.rs
+++ b/blockchain/modules/support/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/support/src/mocks.rs
+++ b/blockchain/modules/support/src/mocks.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/transaction-pause/src/lib.rs
+++ b/blockchain/modules/transaction-pause/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/transaction-pause/src/mock.rs
+++ b/blockchain/modules/transaction-pause/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/transaction-pause/src/tests.rs
+++ b/blockchain/modules/transaction-pause/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/transaction-pause/src/weights.rs
+++ b/blockchain/modules/transaction-pause/src/weights.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/transaction-payment/src/lib.rs
+++ b/blockchain/modules/transaction-payment/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/transaction-payment/src/mock.rs
+++ b/blockchain/modules/transaction-payment/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/transaction-payment/src/tests.rs
+++ b/blockchain/modules/transaction-payment/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/transaction-payment/src/weights.rs
+++ b/blockchain/modules/transaction-payment/src/weights.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/unified-accounts/src/lib.rs
+++ b/blockchain/modules/unified-accounts/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/unified-accounts/src/mock.rs
+++ b/blockchain/modules/unified-accounts/src/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/unified-accounts/src/tests.rs
+++ b/blockchain/modules/unified-accounts/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/unified-accounts/src/weights.rs
+++ b/blockchain/modules/unified-accounts/src/weights.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/modules/vesting/src/lib.rs
+++ b/blockchain/modules/vesting/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/node/Cargo.toml
+++ b/blockchain/node/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-authors = ['Setheum Labs <https://setheum.xyz>']
+authors = [ "Afsall Labs", "Setheum Developers", "Setheum Foundation" ]
 build = 'build.rs'
 description = 'Setheum Network Node'
 edition = '2018'
-homepage = 'https://setheum.xyz'
+homepage = 'https://setheum.com'
 license = 'Unlicense'
 name = 'setheum-node'
-repository = 'https://github.com/Setheum-Labs/Setheum'
+repository = 'https://github.com/setheum/setheum'
 version = '1.0.0'
 
 [[bin]]

--- a/blockchain/node/build.rs
+++ b/blockchain/node/build.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/node/src/chain_spec.rs
+++ b/blockchain/node/src/chain_spec.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/node/src/cli.rs
+++ b/blockchain/node/src/cli.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/node/src/command.rs
+++ b/blockchain/node/src/command.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify
@@ -43,7 +43,7 @@ impl SubstrateCli for Cli {
 	}
 
 	fn support_url() -> String {
-		"https://github.com/Setheum-Labs/Setheum/issues".into()
+		"https://github.com/setheum/setheum/issues".into()
 	}
 
 	fn copyright_start_year() -> i32 {

--- a/blockchain/node/src/lib.rs
+++ b/blockchain/node/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/node/src/main.rs
+++ b/blockchain/node/src/main.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/node/src/rpc.rs
+++ b/blockchain/node/src/rpc.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/node/src/service.rs
+++ b/blockchain/node/src/service.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/predeploy-contracts/package.json
+++ b/blockchain/predeploy-contracts/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.0",
   "main": "index.js",
   "repository": "https://github.com/Setheum-Labs/predeploy-contracts.git",
-  "author": "Setheum Labs <https://setheum.xyz>",
+  "author": "Setheum Labs <https://setheum.com>",
   "contributors": [
     "Muhammad-Jibril B.A. <jbashir52@gmail.com>"
   ],

--- a/blockchain/runtime/Cargo.toml
+++ b/blockchain/runtime/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-authors = ['Setheum Labs <https://setheum.xyz>']
+authors = [ "Afsall Labs", "Setheum Developers", "Setheum Foundation" ]
 version = '1.0.0'
 edition = '2018'
 build = "build.rs"
-homepage = 'https://setheum.xyz'
+homepage = 'https://setheum.com'
 name = 'setheum-runtime'
-repository = 'https://github.com/Setheum-Labs/Setheum'
+repository = 'https://github.com/setheum/setheum'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/blockchain/runtime/build.rs
+++ b/blockchain/runtime/build.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/common/src/gas_to_weight_ratio.rs
+++ b/blockchain/runtime/common/src/gas_to_weight_ratio.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/common/src/lib.rs
+++ b/blockchain/runtime/common/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/common/src/precompile/dex.rs
+++ b/blockchain/runtime/common/src/precompile/dex.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/common/src/precompile/input.rs
+++ b/blockchain/runtime/common/src/precompile/input.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/common/src/precompile/mock.rs
+++ b/blockchain/runtime/common/src/precompile/mock.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/common/src/precompile/mod.rs
+++ b/blockchain/runtime/common/src/precompile/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/common/src/precompile/multicurrency.rs
+++ b/blockchain/runtime/common/src/precompile/multicurrency.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/common/src/precompile/nft.rs
+++ b/blockchain/runtime/common/src/precompile/nft.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/common/src/precompile/oracle.rs
+++ b/blockchain/runtime/common/src/precompile/oracle.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/common/src/precompile/schedule_call.rs
+++ b/blockchain/runtime/common/src/precompile/schedule_call.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/common/src/precompile/state_rent.rs
+++ b/blockchain/runtime/common/src/precompile/state_rent.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/common/src/precompile/tests.rs
+++ b/blockchain/runtime/common/src/precompile/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/common/src/weights/lib.rs
+++ b/blockchain/runtime/common/src/weights/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/authority.rs
+++ b/blockchain/runtime/src/authority.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/benchmarking/auction.rs
+++ b/blockchain/runtime/src/benchmarking/auction.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/benchmarking/auction_manager.rs
+++ b/blockchain/runtime/src/benchmarking/auction_manager.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/benchmarking/authority.rs
+++ b/blockchain/runtime/src/benchmarking/authority.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/benchmarking/cdp_engine.rs
+++ b/blockchain/runtime/src/benchmarking/cdp_engine.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/benchmarking/cdp_treasury.rs
+++ b/blockchain/runtime/src/benchmarking/cdp_treasury.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/benchmarking/currencies.rs
+++ b/blockchain/runtime/src/benchmarking/currencies.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/benchmarking/dex.rs
+++ b/blockchain/runtime/src/benchmarking/dex.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/benchmarking/dex_oracle.rs
+++ b/blockchain/runtime/src/benchmarking/dex_oracle.rs
@@ -1,6 +1,6 @@
 // This file is part of Setheum.
 
-// Copyright (C) 2020-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/benchmarking/emergency_shutdown.rs
+++ b/blockchain/runtime/src/benchmarking/emergency_shutdown.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/benchmarking/evm.rs
+++ b/blockchain/runtime/src/benchmarking/evm.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/benchmarking/evm_accounts.rs
+++ b/blockchain/runtime/src/benchmarking/evm_accounts.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/benchmarking/mod.rs
+++ b/blockchain/runtime/src/benchmarking/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/benchmarking/oracle.rs
+++ b/blockchain/runtime/src/benchmarking/oracle.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/benchmarking/prices.rs
+++ b/blockchain/runtime/src/benchmarking/prices.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/benchmarking/serp_setmint.rs
+++ b/blockchain/runtime/src/benchmarking/serp_setmint.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/benchmarking/serp_treasury.rs
+++ b/blockchain/runtime/src/benchmarking/serp_treasury.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/benchmarking/tokens.rs
+++ b/blockchain/runtime/src/benchmarking/tokens.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/benchmarking/transaction_pause.rs
+++ b/blockchain/runtime/src/benchmarking/transaction_pause.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/benchmarking/transaction_payment.rs
+++ b/blockchain/runtime/src/benchmarking/transaction_payment.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/benchmarking/utils.rs
+++ b/blockchain/runtime/src/benchmarking/utils.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/benchmarking/vesting.rs
+++ b/blockchain/runtime/src/benchmarking/vesting.rs
@@ -1,6 +1,6 @@
 // This file is part of Setheum.
 
-// Copyright (C) 2020-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/constants.rs
+++ b/blockchain/runtime/src/constants.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/lib.rs
+++ b/blockchain/runtime/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/weights/dex_oracle.rs
+++ b/blockchain/runtime/src/weights/dex_oracle.rs
@@ -1,6 +1,6 @@
 // This file is part of Setheum.
 
-// Copyright (C) 2020-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/weights/emergency_shutdown.rs
+++ b/blockchain/runtime/src/weights/emergency_shutdown.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/weights/mod.rs
+++ b/blockchain/runtime/src/weights/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/weights/module_auction_manager.rs
+++ b/blockchain/runtime/src/weights/module_auction_manager.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/weights/module_cdp_engine.rs
+++ b/blockchain/runtime/src/weights/module_cdp_engine.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/weights/module_cdp_treasury.rs
+++ b/blockchain/runtime/src/weights/module_cdp_treasury.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/weights/module_currencies.rs
+++ b/blockchain/runtime/src/weights/module_currencies.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/weights/module_dex.rs
+++ b/blockchain/runtime/src/weights/module_dex.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/weights/module_evm.rs
+++ b/blockchain/runtime/src/weights/module_evm.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/weights/module_evm_accounts.rs
+++ b/blockchain/runtime/src/weights/module_evm_accounts.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/weights/module_nft.rs
+++ b/blockchain/runtime/src/weights/module_nft.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/weights/module_prices.rs
+++ b/blockchain/runtime/src/weights/module_prices.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/weights/module_transaction_pause.rs
+++ b/blockchain/runtime/src/weights/module_transaction_pause.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/weights/module_transaction_payment.rs
+++ b/blockchain/runtime/src/weights/module_transaction_payment.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/weights/module_vesting.rs
+++ b/blockchain/runtime/src/weights/module_vesting.rs
@@ -1,6 +1,6 @@
 // This file is part of Setheum.
 
-// Copyright (C) 2020-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/weights/orml_auction.rs
+++ b/blockchain/runtime/src/weights/orml_auction.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/weights/orml_authority.rs
+++ b/blockchain/runtime/src/weights/orml_authority.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/weights/orml_oracle.rs
+++ b/blockchain/runtime/src/weights/orml_oracle.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/weights/orml_tokens.rs
+++ b/blockchain/runtime/src/weights/orml_tokens.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/weights/serp_setmint.rs
+++ b/blockchain/runtime/src/weights/serp_setmint.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/src/weights/serp_treasury.rs
+++ b/blockchain/runtime/src/weights/serp_treasury.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/blockchain/runtime/tests/weights_test.rs
+++ b/blockchain/runtime/tests/weights_test.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/clisee/src/commands.rs
+++ b/interfaces/clisee/src/commands.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/clisee/src/contracts.rs
+++ b/interfaces/clisee/src/contracts.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/clisee/src/finalization.rs
+++ b/interfaces/clisee/src/finalization.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/clisee/src/keys.rs
+++ b/interfaces/clisee/src/keys.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/clisee/src/lib.rs
+++ b/interfaces/clisee/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/clisee/src/main.rs
+++ b/interfaces/clisee/src/main.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/clisee/src/runtime.rs
+++ b/interfaces/clisee/src/runtime.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/clisee/src/secret.rs
+++ b/interfaces/clisee/src/secret.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/clisee/src/staking.rs
+++ b/interfaces/clisee/src/staking.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/clisee/src/transfer.rs
+++ b/interfaces/clisee/src/transfer.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/clisee/src/treasury.rs
+++ b/interfaces/clisee/src/treasury.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/clisee/src/validators.rs
+++ b/interfaces/clisee/src/validators.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/clisee/src/version_upgrade.rs
+++ b/interfaces/clisee/src/version_upgrade.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/clisee/src/vesting.rs
+++ b/interfaces/clisee/src/vesting.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/clisee/src/vk_storage.rs
+++ b/interfaces/clisee/src/vk_storage.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/Cargo.toml
+++ b/interfaces/setheum-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "setheum_client"
 version = "0.1.0"
 edition = "2021"
-authors = ["Setheum Labs", "Open Web3 Foundation"]
+authors = [ "Afsall Labs", "Setheum Developers", "Setheum Foundation" ]
 documentation = "https://docs.rs/setheum_client"
 readme = "README.md"
 authors.workspace = true
@@ -10,8 +10,8 @@ edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license = "Apache-2.0"
-homepage = "https://setheum.xyz"
-repository = "https://github.com/Setheum-Labs/Setheum"
+homepage = "https://setheum.com"
+repository = "https://github.com/setheum/setheum"
 description = "This crate provides a Rust application interface for submitting transactions to `setheum` chain."
 
 [dependencies]

--- a/interfaces/setheum-client/README.md
+++ b/interfaces/setheum-client/README.md
@@ -1,4 +1,4 @@
-# API for [Setheum](https://github.com/Setheum-Labs/Setheum) chain.
+# API for [Setheum](https://github.com/setheum/setheum) chain.
 
 This crate provides a Rust application interface for submitting transactions to `setheum-node` chain.
 Most of the [pallets](https://docs.substrate.io/reference/frame-pallets/) are common to any

--- a/interfaces/setheum-client/src/connections.rs
+++ b/interfaces/setheum-client/src/connections.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/contract/convertible_value.rs
+++ b/interfaces/setheum-client/src/contract/convertible_value.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/contract/event.rs
+++ b/interfaces/setheum-client/src/contract/event.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/contract/mod.rs
+++ b/interfaces/setheum-client/src/contract/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/lib.rs
+++ b/interfaces/setheum-client/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify
@@ -19,7 +19,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 #![warn(missing_docs)]
-//! API for [setheum](https://github.com/Setheum-Labs/Setheum) chain.
+//! API for [setheum](https://github.com/setheum/setheum) chain.
 //!
 //! This crate provides a Rust application interface for submitting transactions to `setheum` chain.
 //! Most of the [pallets](https://docs.substrate.io/reference/frame-pallets/) are common to any

--- a/interfaces/setheum-client/src/pallets/aleph.rs
+++ b/interfaces/setheum-client/src/pallets/aleph.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/pallets/author.rs
+++ b/interfaces/setheum-client/src/pallets/author.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/pallets/balances.rs
+++ b/interfaces/setheum-client/src/pallets/balances.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/pallets/committee_management.rs
+++ b/interfaces/setheum-client/src/pallets/committee_management.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/pallets/contract.rs
+++ b/interfaces/setheum-client/src/pallets/contract.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/pallets/elections.rs
+++ b/interfaces/setheum-client/src/pallets/elections.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/pallets/feature_control.rs
+++ b/interfaces/setheum-client/src/pallets/feature_control.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/pallets/fee.rs
+++ b/interfaces/setheum-client/src/pallets/fee.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/pallets/mod.rs
+++ b/interfaces/setheum-client/src/pallets/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/pallets/multisig.rs
+++ b/interfaces/setheum-client/src/pallets/multisig.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/pallets/proxy.rs
+++ b/interfaces/setheum-client/src/pallets/proxy.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/pallets/session.rs
+++ b/interfaces/setheum-client/src/pallets/session.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/pallets/staking.rs
+++ b/interfaces/setheum-client/src/pallets/staking.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/pallets/system.rs
+++ b/interfaces/setheum-client/src/pallets/system.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/pallets/timestamp.rs
+++ b/interfaces/setheum-client/src/pallets/timestamp.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/pallets/treasury.rs
+++ b/interfaces/setheum-client/src/pallets/treasury.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/pallets/utility.rs
+++ b/interfaces/setheum-client/src/pallets/utility.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/pallets/vesting.rs
+++ b/interfaces/setheum-client/src/pallets/vesting.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/pallets/vk_storage.rs
+++ b/interfaces/setheum-client/src/pallets/vk_storage.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/runtime_types.rs
+++ b/interfaces/setheum-client/src/runtime_types.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/setheum.rs
+++ b/interfaces/setheum-client/src/setheum.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/utility.rs
+++ b/interfaces/setheum-client/src/utility.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/interfaces/setheum-client/src/waiting.rs
+++ b/interfaces/setheum-client/src/waiting.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/primitives/src/aleph.rs
+++ b/primitives/src/aleph.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/primitives/src/bonding/controller.rs
+++ b/primitives/src/bonding/controller.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/primitives/src/bonding/error.rs
+++ b/primitives/src/bonding/error.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/primitives/src/bonding/ledger.rs
+++ b/primitives/src/bonding/ledger.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/primitives/src/bonding/mod.rs
+++ b/primitives/src/bonding/mod.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/primitives/src/currency.rs
+++ b/primitives/src/currency.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/primitives/src/edfis_launchpad.rs
+++ b/primitives/src/edfis_launchpad.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/primitives/src/evm.rs
+++ b/primitives/src/evm.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/primitives/src/nft.rs
+++ b/primitives/src/nft.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/primitives/src/signature.rs
+++ b/primitives/src/signature.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/primitives/src/task.rs
+++ b/primitives/src/task.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/primitives/src/testing.rs
+++ b/primitives/src/testing.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/primitives/src/tests.rs
+++ b/primitives/src/tests.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/primitives/src/unchecked_extrinsic.rs
+++ b/primitives/src/unchecked_extrinsic.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/primitives/src/vesting.rs
+++ b/primitives/src/vesting.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/rate-limiter/src/lib.rs
+++ b/rate-limiter/src/lib.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/rate-limiter/src/rate_limiter.rs
+++ b/rate-limiter/src/rate_limiter.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/rate-limiter/src/token_bucket.rs
+++ b/rate-limiter/src/token_bucket.rs
@@ -2,7 +2,7 @@
 
 // This file is part of Setheum.
 
-// Copyright (C) 2019-Present Setheum Labs.
+// Copyright (C) 2019-Present Setheum Developers.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify

--- a/tests/flooder/Cargo.toml
+++ b/tests/flooder/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flooder"
 version = "0.3.0"
-authors = ["Setheum Labs"]
+authors = [ "Afsall Labs", "Setheum Developers", "Setheum Foundation" ]
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Adjust project branding and metadata across the repo: update .gitmodules to point the orml submodule to a different fork; change Cargo.toml workspace/package metadata (authors, homepage, repository); update header and runtime weight templates and HEADER-GPL3 to use "Setheum Developers" copyright; and refresh README badges, website link and DeFi/intro wording. These changes align repository metadata and documentation with the new project identity and upstream references.